### PR TITLE
mitigate against runtime panics and resource leaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
     #### expecting it in the form of
     ####   /go/src/github.com/circleci/go-tool
     ####   /go/src/bitbucket.org/circleci/go-tool
-    working_directory: /go/src/github.com/AndroidStudyOpenSource/mpesa-api-go
+    working_directory: /go/src/github.com/twigaeng/mpesa-api-go
     steps:
       - checkout
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MPESA Golang API Wrapper  [![CircleCI](https://circleci.com/gh/AndroidStudyOpenSource/mpesa-api-go.svg?style=shield)](https://circleci.com/gh/AndroidStudyOpenSource/mpesa-api-go)
+# MPESA Golang API Wrapper  [![CircleCI](https://circleci.com/gh/twigaeng/mpesa-api-go.svg?style=shield)](https://circleci.com/gh/twigaeng/mpesa-api-go)
 
 The wrapper provides convenient access to the [Safaricom MPESA Daraja API](https://developer.safaricom.co.ke/apis-explorer) for applications written in server-side Golang. :rocket:
 
@@ -6,7 +6,7 @@ The wrapper provides convenient access to the [Safaricom MPESA Daraja API](https
 You can install the package by running:
 
 ```
-go get github.com/AndroidStudyOpenSource/mpesa-api-go
+go get github.com/twigaeng/mpesa-api-go
 ```
 
 ## Usage
@@ -28,7 +28,7 @@ package main
 
 import (
 	"log"
-	"github.com/AndroidStudyOpenSource/mpesa-api-go"
+	"github.com/twigaeng/mpesa-api-go"
 )
 
 const (
@@ -76,7 +76,7 @@ package main
 
 import (
 	"log"
-	"github.com/AndroidStudyOpenSource/mpesa-api-go"
+	"github.com/twigaeng/mpesa-api-go"
 )
 
 const (
@@ -113,7 +113,7 @@ package main
 
 import (
 	"log"
-	"github.com/AndroidStudyOpenSource/mpesa-api-go"
+	"github.com/twigaeng/mpesa-api-go"
 )
 
 const (
@@ -152,7 +152,7 @@ package main
 
 import (
 	"log"
-	"github.com/AndroidStudyOpenSource/mpesa-api-go"
+	"github.com/twigaeng/mpesa-api-go"
 )
 
 const (
@@ -196,7 +196,7 @@ package main
 
 import (
 	"log"
-	"github.com/AndroidStudyOpenSource/mpesa-api-go"
+	"github.com/twigaeng/mpesa-api-go"
 )
 
 const (
@@ -243,7 +243,7 @@ package main
 
 import (
 	"log"
-	"github.com/AndroidStudyOpenSource/mpesa-api-go"
+	"github.com/twigaeng/mpesa-api-go"
 )
 
 const (
@@ -288,7 +288,7 @@ package main
 
 import (
 	"log"
-	"github.com/AndroidStudyOpenSource/mpesa-api-go"
+	"github.com/twigaeng/mpesa-api-go"
 )
 
 const (

--- a/api.go
+++ b/api.go
@@ -48,13 +48,15 @@ func (m Mpesa) authenticate() (string, error) {
 
 	client := &http.Client{Timeout: 10 * time.Second}
 	response, err := client.Do(request)
+	if response != nil {
+		defer response.Body.Close()
+	}
 	if err != nil {
 		return "", err
 	}
 
 	var authResponse authResponse
 	json.NewDecoder(response.Body).Decode(&authResponse)
-	defer response.Body.Close()
 
 	accessToken := authResponse.AccessToken
 	log.Println("Received access_token: ", accessToken)
@@ -239,12 +241,14 @@ func (m Mpesa) newStringRequest(url string, body []byte, headers map[string]stri
 
 	client := &http.Client{Timeout: 10 * time.Second}
 	response, err := client.Do(request)
+	if response != nil {
+		defer response.Body.Close()
+	}
 	if err != nil {
 		return "", err
 	}
 
 	respBody, err := ioutil.ReadAll(response.Body)
-	defer response.Body.Close()
 	if err != nil {
 		return "", err
 	}

--- a/demo/main.go
+++ b/demo/main.go
@@ -2,7 +2,8 @@ package main
 
 import (
 	"log"
-	"github.com/AndroidStudyOpenSource/mpesa-api-go"
+
+	"github.com/twigaeng/mpesa-api-go"
 )
 
 const (


### PR DESCRIPTION
- I have removed the demo/demo binary file
- I have also renamed the repository source from AndroidStudyOpenSource to twigaeng
- I have also mitigated against resource leaks and panic:
In the original
```go
response, err := client.Do(request)
if err != nil {
    return "", err
}
respBody, err := ioutil.ReadAll(response.Body)
defer response.Body.Close()
```
If the err is non nil, the function would return(ie `return "", err`) and thus the response body wouldn't get closed.


